### PR TITLE
Feature - Add constant numeric multipliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2022-10-20
+
+### Added
+
+- Static numeric multipliers as an alternative to argument values.
+
 ## [1.1.0] - 2022-03-17
 
 ### Changed
@@ -25,10 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/pipedrive/graphql-query-cost/compare/v1.0.0...v1.0.0
 [unreleased]: https://github.com/pipedrive/graphql-query-cost/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/pipedrive/graphql-query-cost/tree/v1.0.1
-
-
-[Unreleased]: https://github.com/pipedrive/graphql-query-cost/compare/v3.0.0...HEAD
+[unreleased]: https://github.com/pipedrive/graphql-query-cost/compare/v3.0.0...HEAD
 [3.0.0]: https://github.com/pipedrive/graphql-query-cost/compare/v2.0.2...v3.0.0
 [2.0.2]: https://github.com/pipedrive/graphql-query-cost/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/pipedrive/graphql-query-cost/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/pipedrive/graphql-query-cost/tree/v2.0.0
+
+
+[Unreleased]: https://github.com/ericachelis/graphql-query-cost/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/ericachelis/graphql-query-cost/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/ericachelis/graphql-query-cost/tree/v3.0.0

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const schema = `
 | complexity     | Int      | Abstract value                                                                                                              |     n \* 1 |          |
 | network        | Int      | Amount of requests required to resolve the field                                                                            |            | n \* 100 |
 | db             | Int      | Amount of db requests or query complexity                                                                                   |            | n \* 100 |
-| mutlipliers    | [String] | Field arguments for multipling the complexity                                                                               |            |          |
+| mutlipliers    | [String] | Field arguments for multipling the complexity. If a number is provided the complexity will be multiplied by the number.     |            |          |
 | useMultipliers | Boolean  | When defined, field complexity will not be multiplied.<br/>Defaults to **true** unless the directive is **not** defined.    |            |          |
 | provides       | [String] | Specify which fields are available for the child on the parent type.<br/>If only those are requested, cost will be ignored. |            |          |
 
@@ -180,7 +180,7 @@ Total cost is 4:
 # Schema
 type Query {
   parents(limit: Int!, names: [String]): [Parent]
-  @cost(complexity: 3, multipliers: ["limit", "names"])
+    @cost(complexity: 3, multipliers: ["limit", "names"])
 }
 
 type Parent {

--- a/lib/calculateCost.test.js
+++ b/lib/calculateCost.test.js
@@ -81,7 +81,7 @@ type Query {
 });
 
 describe('Multipliers on limit param (from cost definition based on @cost directive)', () => {
-	it('Multiplies defined field cost * ($limit + $arrayLimit) ', () => {
+	it('Multiplies defined field cost * ($limit + $arrayLimit)', () => {
 		const typeDefs = `type Query { field(limit: Int, arrayLimit: [String]): [String] }`;
 		const costMap = {
 			Query: {
@@ -97,6 +97,22 @@ describe('Multipliers on limit param (from cost definition based on @cost direct
 		const cost = calculateCost(query, typeDefs, { costMap, variables });
 
 		expect(cost).toEqual(4 * (8 + 2));
+	});
+
+	it('Multiplies constant numeric multipliers', () => {
+		const typeDefs = `type Mutation { field: [String] }`;
+		const costMap = {
+			Mutation: {
+				field: {
+					complexity: 4,
+					multipliers: [10],
+				},
+			},
+		};
+		const query = `mutation { field }`;
+		const variables = {};
+		const cost = calculateCost(query, typeDefs, { costMap, variables });
+		expect(cost).toEqual(4 * 10);
 	});
 
 	it('Uses length of an array($limitArray) param as a multiplier', () => {
@@ -609,7 +625,7 @@ describe('tokens', () => {
 		},
 	};
 
-	it('Adds tokens as extra cost, when there are no parent multipliers ', () => {
+	it('Adds tokens as extra cost, when there are no parent multipliers', () => {
 		const limit = 8;
 		const cost = calculateCost(
 			`query {

--- a/lib/costExtractor.js
+++ b/lib/costExtractor.js
@@ -133,13 +133,15 @@ function extractDirectiveValues(typeDefs, directive, argValidators) {
 
 const isArrayOfStrings = (v) =>
 	_.isArray(v) && !_.isEmpty(v) && _.every(v, _.isString);
+const isArrayOfStringsOrNumbers = (v) =>
+	_.isArray(v) && !_.isEmpty(v) && _.every(v, _.isString || _.isNumber);
 
 module.exports = (typeDefs) => {
 	const { costMap, cleanSchema } = extractDirectiveValues(typeDefs, 'cost', {
 		complexity: _.isNumber,
 		network: _.isNumber,
 		db: _.isNumber,
-		multipliers: isArrayOfStrings,
+		multipliers: isArrayOfStringsOrNumbers,
 		useMultipliers: _.isBoolean,
 		provides: isArrayOfStrings,
 	});

--- a/lib/costExtractor.js
+++ b/lib/costExtractor.js
@@ -131,10 +131,11 @@ function extractDirectiveValues(typeDefs, directive, argValidators) {
 	};
 }
 
+const isStringOrNumber = (v) => (_.isString(v) || _.isNumber(v));
 const isArrayOfStrings = (v) =>
 	_.isArray(v) && !_.isEmpty(v) && _.every(v, _.isString);
 const isArrayOfStringsOrNumbers = (v) =>
-	_.isArray(v) && !_.isEmpty(v) && _.every(v, _.isString || _.isNumber);
+	_.isArray(v) && !_.isEmpty(v) && _.every(v, isStringOrNumber);
 
 module.exports = (typeDefs) => {
 	const { costMap, cleanSchema } = extractDirectiveValues(typeDefs, 'cost', {

--- a/lib/costVisitor.js
+++ b/lib/costVisitor.js
@@ -63,7 +63,13 @@ function getFieldMultiplier(ast, multipliers = [], fieldArgValues) {
 		}
 	}
 
-	return sum(multipliers.map((key) => multiplierValues[key]));
+	for (const multiplier of multipliers) {
+		if (!isNaN(multiplier)) {
+			multiplierValues[`${multiplier}`] = multiplier;
+		}
+	}
+
+	return sum(multipliers.map((key) => multiplierValues[`${key}`]));
 }
 
 function getFieldInfo(typeDefs, ast, variables) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedrive/graphql-query-cost",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedrive/graphql-query-cost",
-      "version": "2.0.2",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "graphql": "15.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedrive/graphql-query-cost",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Graphql query cost analysis utils",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
## Problem

Multipliers are a powerful concept, but only work when an input argument is provided. I want to be able to define a constant/static numeric multiplier for a given field.

## Solution
Numeric values can now be passed to the `multipliers` array, and if present will act as a multiplier with a constant value. 

## Changes

- Added the constant/numeric multipliers as an option for calculating query cost
